### PR TITLE
Emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'sqlite3'
   gem "factory_girl_rails", "~> 4.0"
   gem 'multi_json'
+  gem 'webrat' # for "contains" methods and similar in specs.
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     mime-types (1.21)
     multi_json (1.6.1)
     multipart-post (1.1.5)
+    nokogiri (1.5.6)
     oauth2 (0.8.0)
       faraday (~> 0.8)
       httpauth (~> 0.1)
@@ -174,6 +175,10 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
     warden (1.2.1)
       rack (>= 1.0)
+    webrat (0.7.3)
+      nokogiri (>= 1.2.0)
+      rack (>= 1.0)
+      rack-test (>= 0.5.3)
 
 PLATFORMS
   ruby
@@ -199,3 +204,4 @@ DEPENDENCIES
   thin
   twitter-bootstrap-rails (= 2.1.6)
   uglifier (>= 1.0.3)
+  webrat

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,7 @@ class Ability
     if user
       # managing your own user settings
       can :update, User, :id => user.id
+      can :read_email, :all
     end
   end
 end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,6 +7,11 @@
 %b Time zone: 
 = @user.tz_string
 
+-if can? :read_email, @user
+  %br
+  %b Email address:
+  = @user.email || "not set"
+
 -if can? :edit, @user
   %br
   = link_to 'Edit', edit_user_path(@user), :class => 'btn'

--- a/spec/views/user/edit.html.haml_spec.rb
+++ b/spec/views/user/edit.html.haml_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe "user/edit.html.haml" do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/user/update.html.haml_spec.rb
+++ b/spec/views/user/update.html.haml_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe "user/update.html.haml" do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/views/users/show.html.haml_spec.rb
+++ b/spec/views/users/show.html.haml_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'users/show.html.haml', :type => 'view' do
+  before(:each) do
+    @user = assign(:user, FactoryGirl.create(:user))
+  end
+
+  context 'signed out' do
+    before(:each) do
+      controller.stub(:current_user) { nil }
+      render
+    end
+
+    it 'should not show an email address' do
+      rendered.should_not contain "Email address:"
+      rendered.should_not contain @user.email
+    end
+  end
+
+  context 'signed in' do
+    before(:each) do
+      @me = FactoryGirl.create(:user)
+      controller.stub(:current_user) { @me }
+      render
+    end
+
+    it 'should show an email address' do
+      rendered.should contain "Email address:"
+      rendered.should contain @user.email
+    end
+  end
+end


### PR DESCRIPTION
Show email addresses on user profile pages. I am unconvinced by this change, because it means that anyone with a GitHub account can see your supposedly private GitHub email address, and anyone can get a GitHub account. But I'm sending a PR so we have something concrete to discuss.
